### PR TITLE
Fix API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ SESSION_EXPIRE_MINUTES=30
 MAX_FILE_SIZE=52428800  # 50MB
 
 # Frontend
-VITE_API_URL=http://localhost:8000
+VITE_API_URL=http://localhost:8000/api
 ```
 
 ### Personnalisation des entités

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - ./frontend:/app
       - /app/node_modules
     environment:
-      - REACT_APP_API_URL=http://localhost:9991
+      - VITE_API_URL=http://localhost:9991/api
     command: npm run dev
 
   redis:

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,2 @@
-VITE_API_URL=http://localhost:9991
+# Adresse de base de l'API backend incluant le préfixe /api
+VITE_API_URL=http://localhost:9991/api


### PR DESCRIPTION
## Summary
- update frontend environment variable to use `/api`
- set docker-compose to pass the correct Vite API URL
- document API base URL in README

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails due to TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6887465aebe0832da620b12c40dc478d