### PR TITLE
Remove unused aioredis dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,5 +12,4 @@ python-jose[cryptography]>=3.3.0
 pdf2image>=1.16.0
 Pillow>=10.0.0
 aiofiles>=24.1.0
-aioredis>=2.0.1
 requests>=2.31.0


### PR DESCRIPTION
## Summary
- remove `aioredis` from `backend/requirements.txt`

## Testing
- `pip install -r backend/requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_688781628b40832d94dd6e90b11f0a09