### PR TITLE
Restore DocumentProcessor intelligent replacements

### DIFF
--- a/backend/app/services/document_processor.py
+++ b/backend/app/services/document_processor.py
@@ -4,7 +4,7 @@
 import io
 import logging
 import re  # ✅ AJOUTER CETTE LIGNE
-from typing import BinaryIO, Tuple, Dict
+from typing import BinaryIO, Tuple, Dict, List
 from docx import Document
 from docx.shared import Inches
 import PyPDF2
@@ -13,13 +13,83 @@ from pdf2image import convert_from_bytes
 from PIL import Image
 import tempfile
 import os
+from .replacement_engine import IntelligentReplacementEngine
 
 logger = logging.getLogger(__name__)
 
 class DocumentProcessor:
     def __init__(self):
         self.supported_extensions = ['.pdf', '.docx']
-    
+
+    def process_uploaded_file(self, file_content: bytes, filename: str) -> Tuple[Document, str]:
+        """Traite un fichier uploadé et renvoie un Document et son texte."""
+        extension = os.path.splitext(filename)[1].lower()
+
+        if extension == '.docx':
+            return self._process_docx(file_content)
+        elif extension == '.pdf':
+            return self._process_pdf(file_content)
+        else:
+            raise ValueError(f"Format de fichier non supporté: {extension}")
+
+    def _process_pdf(self, pdf_content: bytes) -> Tuple[Document, str]:
+        """Traite un PDF en tentant d'extraire le texte puis en OCR si besoin."""
+        text = self._extract_text_from_pdf(pdf_content)
+        if len(text.strip()) < 100:
+            text = self._ocr_pdf_with_tesseract(pdf_content)
+        doc = self._create_docx_from_text(text)
+        return doc, text
+
+    def _process_docx(self, docx_content: bytes) -> Tuple[Document, str]:
+        """Charge un DOCX et en extrait le texte."""
+        stream = io.BytesIO(docx_content)
+        document = Document(stream)
+        text = self._extract_text_from_docx(document)
+        return document, text
+
+    def _extract_text_from_pdf(self, pdf_content: bytes) -> str:
+        text = ""
+        try:
+            reader = PyPDF2.PdfReader(io.BytesIO(pdf_content))
+            for page in reader.pages:
+                page_text = page.extract_text()
+                if page_text:
+                    text += page_text + "\n"
+        except Exception as e:
+            logger.error(f"Erreur lors de l'extraction PDF: {e}")
+        return text
+
+    def _ocr_pdf_with_tesseract(self, pdf_content: bytes) -> str:
+        text = ""
+        try:
+            images = convert_from_bytes(pdf_content, dpi=300)
+            for image in images:
+                page_text = pytesseract.image_to_string(image, lang='fra', config='--psm 6')
+                text += page_text + "\n"
+        except Exception as e:
+            logger.error(f"Erreur lors de l'OCR: {e}")
+        return text
+
+    def _extract_text_from_docx(self, document: Document) -> str:
+        parts = []
+        for paragraph in document.paragraphs:
+            if paragraph.text.strip():
+                parts.append(paragraph.text)
+        for table in document.tables:
+            for row in table.rows:
+                for cell in row.cells:
+                    if cell.text.strip():
+                        parts.append(cell.text)
+        return "\n".join(parts)
+
+    def _create_docx_from_text(self, text: str) -> Document:
+        document = Document()
+        document.add_heading('Document converti', 0)
+        for line in text.split('\n'):
+            if line.strip():
+                document.add_paragraph(line.strip())
+        return document
+
     # ... GARDER TOUTES LES AUTRES MÉTHODES INCHANGÉES ...
     
     def apply_global_replacements(self, document: Document, replacements: dict) -> bytes:
@@ -86,9 +156,97 @@ class DocumentProcessor:
                     paragraph.add_run("")
                 
                 paragraph.runs[0].text = modified_text
-                
+
         except Exception as e:
             logger.debug(f"Erreur replacement: {e}")
+
+    def apply_intelligent_replacements(self, document: Document, entities_data: List[Dict],
+                                       groups_data: List[Dict] = None) -> bytes:
+        """Applique les remplacements en évitant les conflits."""
+        try:
+            logger.info("🚀 Début de l'anonymisation intelligente")
+
+            engine = IntelligentReplacementEngine()
+
+            if groups_data:
+                for group in groups_data:
+                    group_replacement = group.get('replacement', 'GROUPE_X')
+                    entity_ids = group.get('entity_ids', [])
+
+                    for entity_data in entities_data:
+                        if entity_data.get('selected') and entity_data.get('id') in entity_ids:
+                            engine.add_replacement(
+                                original=entity_data['text'],
+                                replacement=group_replacement,
+                                entity_id=entity_data['id'],
+                                is_grouped=True,
+                                group_id=group.get('id')
+                            )
+                            logger.info(f"Groupe ajouté: '{entity_data['text']}' -> '{group_replacement}'")
+
+            for entity_data in entities_data:
+                if entity_data.get('selected') and not entity_data.get('is_grouped', False):
+                    engine.add_replacement(
+                        original=entity_data['text'],
+                        replacement=entity_data['replacement'],
+                        entity_id=entity_data['id'],
+                        is_grouped=False
+                    )
+                    logger.info(f"Entité ajoutée: '{entity_data['text']}' -> '{entity_data['replacement']}'")
+
+            self._apply_replacements_to_document(document, engine)
+
+            report = engine.get_replacement_report()
+            logger.info(
+                f"📊 Rapport d'anonymisation: {report['total_rules']} règles, {report['active_rules']} actives, {report['grouped_rules']} groupées")
+
+            output_stream = io.BytesIO()
+            document.save(output_stream)
+            output_stream.seek(0)
+
+            logger.info("✅ Anonymisation intelligente terminée")
+            return output_stream.read()
+
+        except Exception as e:
+            logger.error(f"Erreur lors de l'anonymisation intelligente: {e}")
+            raise ValueError(f"Impossible d'appliquer l'anonymisation: {e}")
+
+    def _apply_replacements_to_document(self, document: Document, engine: IntelligentReplacementEngine):
+        """Applique les remplacements à toutes les parties du document."""
+        replacements_count = 0
+
+        for paragraph in document.paragraphs:
+            if paragraph.text.strip():
+                original_text = paragraph.text
+                new_text, stats = engine.apply_replacements(original_text)
+
+                if new_text != original_text:
+                    self._replace_paragraph_text(paragraph, new_text)
+                    replacements_count += sum(stats.values())
+
+        for table in document.tables:
+            for row in table.rows:
+                for cell in row.cells:
+                    for paragraph in cell.paragraphs:
+                        if paragraph.text.strip():
+                            original_text = paragraph.text
+                            new_text, stats = engine.apply_replacements(original_text)
+
+                            if new_text != original_text:
+                                self._replace_paragraph_text(paragraph, new_text)
+                                replacements_count += sum(stats.values())
+
+        logger.info(f"✅ {replacements_count} remplacements appliqués dans le document")
+
+    def _replace_paragraph_text(self, paragraph, new_text: str):
+        """Remplace le texte d'un paragraphe en préservant le formatage."""
+        for run in paragraph.runs:
+            run.text = ""
+
+        if paragraph.runs:
+            paragraph.runs[0].text = new_text
+        else:
+            paragraph.add_run(new_text)
 
 # Instance globale inchangée
 document_processor = DocumentProcessor()

--- a/frontend/src/pages/EntityControlPage.tsx
+++ b/frontend/src/pages/EntityControlPage.tsx
@@ -786,11 +786,154 @@ const EnhancedEntityControlPage: React.FC = () => {
                   onChange={(e) => setCustomEntityForm({...customEntityForm, text: e.target.value})}
                   className="w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
                 />
-                <select 
+                <select
                   value={customEntityForm.entity_type}
-                  onChange={(e) => setCustomEntityForm({...customEntityForm, entity_type: e.target.value as EntityType})}
+                  onChange={(e) =>
+                    setCustomEntityForm({
+                      ...customEntityForm,
+                      entity_type: e.target.value as EntityType,
+                    })
+                  }
                   className="w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
                 >
-                  {Object.values(EntityType).map(type => (
-                    <option key={type} value={type}>{type}</option>
+                  {Object.values(EntityType).map((type) => (
+                    <option key={type} value={type}>
+                      {type}
+                    </option>
                   ))}
+                </select>
+                <input
+                  type="text"
+                  placeholder="Remplacer par..."
+                  value={customEntityForm.replacement}
+                  onChange={(e) =>
+                    setCustomEntityForm({
+                      ...customEntityForm,
+                      replacement: e.target.value,
+                    })
+                  }
+                  className="w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <button
+                  onClick={handleAddCustomEntity}
+                  className="w-full bg-green-600 text-white py-2 rounded hover:bg-green-700 transition-colors"
+                >
+                  Ajouter
+                </button>
+              </div>
+            </div>
+
+            {/* Nouvelles fonctionnalités */}
+            <div className="bg-gradient-to-r from-purple-50 to-blue-50 rounded-xl p-6 border border-purple-200">
+              <h3 className="font-semibold mb-4 text-purple-800">🆕 Nouvelles fonctionnalités</h3>
+              <div className="space-y-3 text-sm">
+                <div className="flex items-center gap-2">
+                  <Edit3 size={14} className="text-blue-600" />
+                  <span><strong>Modification d'entités</strong> : Éditez le texte à anonymiser</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Shuffle size={14} className="text-purple-600" />
+                  <span><strong>Groupement d'entités</strong> : Anonymisez plusieurs variantes ensemble</span>
+                </div>
+                <div className="text-xs text-gray-600 mt-2">
+                  💡 Exemple : Grouper "Monsieur OULHADJ" et "Monsieur Saïd OULHADJ" pour les remplacer tous deux par "Monsieur X"
+                </div>
+              </div>
+            </div>
+
+            {/* Statistiques */}
+            {stats && (
+              <div className="bg-white rounded-xl shadow-sm p-6">
+                <h3 className="font-semibold mb-4">Statistiques</h3>
+                <div className="space-y-3">
+                  {Object.entries(stats.by_type).map(([type, count]) => {
+                    const config = getEntityTypeConfig(type);
+                    return (
+                      <div key={type} className="flex items-center justify-between">
+                        <span className="flex items-center gap-2 text-sm">
+                          <span>{config.icon}</span>
+                          <span>{type}</span>
+                        </span>
+                        <span className="text-sm font-medium">{count}</span>
+                      </div>
+                    );
+                  })}
+                  {entityGroups.length > 0 && (
+                    <div className="flex items-center justify-between pt-2 border-t">
+                      <span className="flex items-center gap-2 text-sm">
+                        <span>🔗</span>
+                        <span>Groupes</span>
+                      </span>
+                      <span className="text-sm font-medium">{entityGroups.length}</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Bouton de génération */}
+            <div className="bg-blue-50 rounded-xl p-6 border-2 border-blue-200">
+              <div className="text-center mb-4">
+                <Shield size={24} className="mx-auto text-blue-600 mb-2" />
+                <h3 className="font-semibold text-lg">Prêt pour l'anonymisation</h3>
+                <p className="text-sm text-gray-600 mt-2">
+                  {selectedCount} entités sélectionnées<br />
+                  Format DOCX préservé • Conformité RGPD
+                </p>
+              </div>
+              <button
+                disabled={selectedCount === 0 || isGenerating}
+                onClick={handleGenerateDocument}
+                className="w-full bg-blue-600 text-white py-3 rounded-lg font-semibold hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
+              >
+                {isGenerating ? (
+                  <>
+                    <div className="animate-spin w-5 h-5 border-2 border-white border-t-transparent rounded-full"></div>
+                    Génération...
+                  </>
+                ) : (
+                  <>
+                    <Download size={20} />
+                    Générer document anonymisé
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Vues de groupement */}
+      {showGroupForm && (
+        <GroupementForm
+          entities={entities}
+          onCreateGroup={createGroup}
+          onClose={() => setShowGroupForm(false)}
+        />
+      )}
+      {showAutoGroupModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white p-6 rounded-xl shadow-lg space-y-4">
+            <h3 className="font-semibold text-lg">Grouper les entités similaires ?</h3>
+            <div className="flex gap-3 justify-end">
+              <button
+                onClick={() => setShowAutoGroupModal(false)}
+                className="px-4 py-2 bg-gray-100 rounded hover:bg-gray-200"
+              >
+                Annuler
+              </button>
+              <button
+                onClick={autoGroupSimilarEntities}
+                className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+              >
+                Confirmer
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default EnhancedEntityControlPage;


### PR DESCRIPTION
## Summary
- bring back the intelligent replacement helpers
- update imports to include `IntelligentReplacementEngine`
- all Python tests pass again

## Testing
- `pytest -q`
- `npm run lint` *(fails: eslint not found)*
- `npm run build` *(fails: tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889d79853e4832daded6c6bf6e22c93