### PR TITLE
Check torch.jit.set_fuser availability

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,7 +47,8 @@ def configure_pytorch_safe():
         torch.set_num_interop_threads(1)
         
         # Désactiver JIT et optimisations
-        torch.jit.set_fuser('fuser0')
+        if hasattr(torch.jit, "set_fuser"):
+            torch.jit.set_fuser("fuser0")
         torch._C._jit_set_profiling_mode(False)
         torch._C._jit_set_profiling_executor(False)
         


### PR DESCRIPTION
## Summary
- Ensure PyTorch fuser configuration only runs when available

## Testing
- `pytest` *(fails: AttributeError: 'RegexAnonymizer' object has no attribute 'anonymize_text', AssertionError: 0 != 2)*

------
https://chatgpt.com/codex/tasks/task_e_68a719685b78832da3d876082cb28e0b