### PR TITLE
Handle thread configuration safely

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,8 +43,10 @@ def configure_pytorch_safe():
         import torch
         
         # Configuration threads
-        torch.set_num_threads(1)
-        torch.set_num_interop_threads(1)
+        try:
+            torch.set_num_threads(1)
+        except Exception as thread_error:
+            logging.warning(f"PyTorch thread configuration warning: {thread_error}")
         
         # Désactiver JIT et optimisations
         if hasattr(torch.jit, "set_fuser"):


### PR DESCRIPTION
## Summary
- wrap PyTorch thread configuration in try/except
- remove interop thread configuration

## Testing
- `pytest -q` *(fails: AttributeError: 'RegexAnonymizer' object has no attribute 'anonymize_text')*

------
https://chatgpt.com/codex/tasks/task_e_68a71c4157ec832dbbca882058578c90