### PR TITLE
fix: use general conflict resolver

### DIFF
--- a/src/anonymizer.py
+++ b/src/anonymizer.py
@@ -424,8 +424,8 @@ class RegexAnonymizer:
             for i, accepted in enumerate(filtered_entities):
                 if self._entities_overlap(entity, accepted):
                     # Résoudre le conflit selon des règles de priorité
-                    winner = self._resolve_overlap_conflict(entity, accepted)
-                    
+                    winner = self._resolve_conflict(entity, accepted)
+
                     if winner == entity:
                         filtered_entities[i] = entity
                     


### PR DESCRIPTION
## Summary
- replace deprecated `_resolve_overlap_conflict` call with `_resolve_conflict` in `RegexAnonymizer._remove_overlapping_entities`
- ensure no leftover references to `_resolve_overlap_conflict`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7251dbd30832db4c2bc66b0d3f882