### PR TITLE
Hide entity checkbox label to remove warning

### DIFF
--- a/main.py
+++ b/main.py
@@ -888,9 +888,10 @@ def display_entities_tab_advanced():
                 with entity_col1:
                     # Checkbox de sélection
                     is_selected = st.checkbox(
-                        "", 
+                        "Sélectionner l'entité",
                         value=select_all,
-                        key=f"select_entity_{i}_{entity['id']}"
+                        key=f"select_entity_{i}_{entity['id']}",
+                        label_visibility="collapsed",
                     )
                     if is_selected:
                         selected_entities.append(entity)


### PR DESCRIPTION
## Summary
- add hidden label for entity selection checkbox to avoid warning

## Testing
- `pytest -q`
- `streamlit run main.py --server.headless true --server.port 8501`

------
https://chatgpt.com/codex/tasks/task_e_68a72b8ea468832d874458eaf887362f