### PR TITLE
Use average confidence metric in analysis tab

### DIFF
--- a/main.py
+++ b/main.py
@@ -1249,7 +1249,7 @@ def display_analysis_tab():
     
     with col2:
         if stats['confidence_stats']:
-            st.metric("Confiance Moyenne", f"{stats['confidence_stats']['avg']:.0%}")
+            st.metric("Confiance Moyenne", f"{stats['confidence_stats'].get('average', 0):.0%}")
             st.metric("Confiance Minimale", f"{stats['confidence_stats']['min']:.0%}")
             st.metric("Confiance Maximale", f"{stats['confidence_stats']['max']:.0%}")
     


### PR DESCRIPTION
## Summary
- Fix advanced analysis confidence display to use `average` metric key with fallback when missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a73123687c832d8b9b3c08e2af2c37