### PR TITLE
Normalize curly quotes in preprocessing

### DIFF
--- a/src/anonymizer.py
+++ b/src/anonymizer.py
@@ -2054,8 +2054,8 @@ class DocumentAnonymizer:
             'œ': 'oe', 'Œ': 'OE',
             'æ': 'ae', 'Æ': 'AE',
             '«': '"', '»': '"',
-            ''': "'", ''': "'",
-            '"': '"', '"': '"'
+            '“': '"', '”': '"',
+            '‘': "'", '’': "'",
         }
         
         for old, new in replacements.items():

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -304,6 +304,12 @@ class TestDocumentAnonymizer(unittest.TestCase):
     
     def setUp(self):
         self.anonymizer = DocumentAnonymizer()
+
+    def test_preprocess_text_normalizes_quotes(self):
+        """Vérifie la normalisation des guillemets typographiques"""
+        text = "“Bonjour” et ‘merci’"
+        processed = self.anonymizer._preprocess_text(text)
+        self.assertEqual(processed, '"Bonjour" et \'merci\'')
     
     def test_create_anonymized_document(self):
         """Test de création de document anonymisé avec options"""


### PR DESCRIPTION
## Summary
- Normalize French and curly quotes to ASCII in preprocessing
- Add unit test to verify normalization of typographic quotes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a81b26f620832daa689c77e4d770f5