### PR TITLE
Add audit reporting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,25 @@ anonymizer-streamlit/
 - **Format** : DOCX préservant la structure originale
 - **Téléchargement** : Direct depuis l'interface
 
+### **6. Rapport d'audit optionnel**
+Les méthodes `process_document` et `export_anonymized_document` acceptent un paramètre `audit`.
+Lorsqu'il est activé (`audit=True`), un rapport détaillant les métadonnées et les statistiques
+d'anonymisation est ajouté ou généré séparément.
+
+```python
+from src.anonymizer import DocumentAnonymizer
+
+anonymizer = DocumentAnonymizer()
+
+# Traitement avec rapport d'audit
+result = anonymizer.process_document("contrat.pdf", audit=True)
+
+# Export en incluant le rapport
+export_path = anonymizer.export_anonymized_document(
+    "contrat.txt", options={"format": "txt"}, audit=True
+)
+```
+
 ## ⚙️ **Configuration Avancée**
 
 ### **Variables d'Environnement**

--- a/main.py
+++ b/main.py
@@ -540,7 +540,7 @@ def process_document_core(file_content, filename, mode, confidence, preset):
         anonymizer = get_anonymizer()
         
         # Traitement avec gestion d'erreurs robuste
-        result = anonymizer.process_document(temp_path, mode, confidence)
+        result = anonymizer.process_document(temp_path, mode, confidence, audit=False)
         
         return result
         
@@ -1438,16 +1438,16 @@ def display_export_section_advanced():
                 export_options = {
                     "format": export_format,
                     "watermark": watermark_text if add_watermark else None,
-                    "include_report": generate_report,
-                    "include_stats": include_stats
                 }
+                audit_flag = generate_report or include_stats
                 
                 # Exporter
                 anonymizer = get_anonymizer()
                 result = anonymizer.export_anonymized_document(
                     st.session_state.processed_file_path,
                     st.session_state.entities,
-                    export_options
+                    export_options,
+                    audit=audit_flag,
                 )
                 
                 # Téléchargement

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -16,7 +16,7 @@ Usage:
     from src.entity_manager import EntityManager
     
     anonymizer = DocumentAnonymizer()
-    result = anonymizer.process_document("document.pdf", mode="ai")
+    result = anonymizer.process_document("document.pdf", mode="ai", audit=False)
 """
 
 __version__ = "2.0.0"

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -336,15 +336,14 @@ class TestDocumentAnonymizer(unittest.TestCase):
                 entities,
                 export_format="txt",
                 watermark="WM",
-                include_report=True,
-                include_stats=True,
+                audit=True,
             )
 
             self.assertTrue(os.path.exists(result_path))
             with open(result_path, "r", encoding="utf-8") as rf:
                 content = rf.read()
             self.assertIn("WM", content)
-            self.assertIn("METADATA", content)
+            self.assertIn("AUDIT REPORT", content)
             self.assertIn("STATISTICS", content)
 
             os.unlink(result_path)
@@ -394,7 +393,7 @@ class TestDocumentAnonymizer(unittest.TestCase):
             "start": 7,
             "end": 23,
         }
-        options = {"format": "txt", "watermark": "WM", "audit": True, "include_stats": True}
+        options = {"format": "txt", "watermark": "WM"}
 
         try:
             with mock.patch.object(
@@ -402,7 +401,9 @@ class TestDocumentAnonymizer(unittest.TestCase):
                 'process_file',
                 wraps=self.anonymizer.document_processor.process_file
             ) as mocked_proc:
-                result_path = self.anonymizer.export_anonymized_document(temp_path, [entity], options)
+                result_path = self.anonymizer.export_anonymized_document(
+                    temp_path, [entity], options, audit=True
+                )
                 mocked_proc.assert_called_once_with(temp_path)
 
             self.assertTrue(os.path.exists(result_path))


### PR DESCRIPTION
## Summary
- allow `process_document` and export helpers to append audit reports with metadata and statistics
- thread audit flag through CLI options
- document new audit parameter and usage

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a822ec8e58832db2e4827043d1d04d