### PR TITLE
Validate export path input

### DIFF
--- a/main.py
+++ b/main.py
@@ -1488,7 +1488,7 @@ def display_export_section_advanced():
                 else:
                     st.error("❌ Erreur lors de l'export du document")
 
-            except (OSError, RuntimeError) as e:
+            except (OSError, RuntimeError, ValueError) as e:
                 # Export may fail due to filesystem or document issues
                 st.error(f"❌ Erreur: {str(e)}")
             finally:

--- a/src/anonymizer.py
+++ b/src/anonymizer.py
@@ -1759,6 +1759,14 @@ class DocumentAnonymizer:
         audit: bool = False,
     ) -> str:
         """Exporter un document anonymisé dans le format souhaité."""
+
+        if (
+            not isinstance(original_path, str)
+            or not original_path
+            or not os.path.exists(original_path)
+        ):
+            raise ValueError("original_path is required for export")
+
         options = options or {}
         output_format = options.get("format", "txt").lower()
 

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -525,6 +525,11 @@ class TestDocumentAnonymizer(unittest.TestCase):
             if 'result_path' in locals() and os.path.exists(result_path):
                 os.unlink(result_path)
 
+    def test_export_anonymized_document_invalid_path(self):
+        """L'export échoue si le chemin fourni est invalide"""
+        with self.assertRaises(ValueError):
+            self.anonymizer.export_anonymized_document("", None, {"format": "txt"})
+
 class TestIntegration(unittest.TestCase):
     """Tests d'intégration"""
     


### PR DESCRIPTION
## Summary
- validate `original_path` in `export_anonymized_document` and raise `ValueError` when invalid
- handle `ValueError` in Streamlit app
- add unit test for invalid export path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a833d56df0832dbb386352cab90feb