### PR TITLE
Document fpdf requirement for PDF export

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Cette application Streamlit permet d'anonymiser automatiquement les documents ju
   - **IA** : Intelligent avec NER pour PERSON, ORG, LOC
 - 🎯 **Gestion d'entités** : Modification, groupement, validation
 - 📊 **Statistiques en temps réel** : Graphiques et métriques
-- 📤 **Export avancé** : DOCX avec filigrane et rapport d'audit
+- 📤 **Export avancé** : DOCX et PDF avec filigrane et rapport d'audit (PDF nécessite `fpdf`)
 - 🛡️ **Conformité RGPD** : Standards CNIL respectés
 
 ## 🚀 **Installation et Démarrage Rapide**
@@ -115,7 +115,7 @@ anonymizer-streamlit/
 
 ### **5. Export Final**
 - **Options** : Filigrane personnalisable, rapport d'audit
-- **Format** : DOCX préservant la structure originale
+- **Format** : DOCX ou PDF (l'export PDF nécessite le package `fpdf`)
 - **Téléchargement** : Direct depuis l'interface
 
 ### **6. Rapport d'audit optionnel**

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,7 @@ seaborn>=0.12.0,<1.0.0
 
 # === TRAITEMENT D'IMAGES ET DOCUMENTS ===
 Pillow>=9.5.0,<11.0.0
+fpdf>=2.7  # Export PDF
 reportlab>=4.0.0  # Pour génération PDF
 
 # === UTILITAIRES SYSTÈME ===

--- a/src/anonymizer.py
+++ b/src/anonymizer.py
@@ -1848,7 +1848,7 @@ class DocumentAnonymizer:
         entities: Optional[List[Entity]]
             Liste d'entités détectées.
         export_format: str
-            Format d'export (txt, docx, pdf).
+            Format d'export (txt, docx, pdf - nécessite le paquet fpdf).
         watermark: Optional[str]
             Filigrane à ajouter au document.
         audit: bool
@@ -2040,7 +2040,9 @@ class DocumentAnonymizer:
             try:
                 from fpdf import FPDF
             except ImportError as e:
-                raise RuntimeError("PDF export requires fpdf") from e
+                raise RuntimeError(
+                    "PDF export requires the 'fpdf' package. Install it with 'pip install fpdf'."
+                ) from e
 
             output_path = os.path.join(
                 self.temp_dir, f"anonymized_{uuid.uuid4().hex[:8]}.pdf"
@@ -2206,7 +2208,9 @@ class DocumentAnonymizer:
             try:
                 from fpdf import FPDF
             except ImportError as e:
-                raise Exception("Export PDF non supporté") from e
+                raise RuntimeError(
+                    "PDF export requires the 'fpdf' package. Install it with 'pip install fpdf'."
+                ) from e
 
             pdf = FPDF()
             pdf.set_auto_page_break(auto=True, margin=15)


### PR DESCRIPTION
## Summary
- Declare `fpdf` dependency for generating PDFs.
- Raise clear runtime errors instructing users to install `fpdf` when missing.
- Update documentation to highlight the `fpdf` requirement for PDF export.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a835e17250832d9fd5a8db84f27f44