### PR TITLE
Disable advanced export options by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Cette application Streamlit permet d'anonymiser automatiquement les documents ju
   - **IA** : Intelligent avec NER pour PERSON, ORG, LOC
 - 🎯 **Gestion d'entités** : Modification, groupement, validation
 - 📊 **Statistiques en temps réel** : Graphiques et métriques
-- 📤 **Export avancé** : DOCX et PDF avec filigrane et rapport d'audit (PDF nécessite `fpdf`)
+- 📤 **Export avancé** : DOCX et PDF avec options de filigrane, rapport d'audit et statistiques (désactivées par défaut ; PDF nécessite `fpdf`)
 - 🛡️ **Conformité RGPD** : Standards CNIL respectés
 
 ## 🚀 **Installation et Démarrage Rapide**
@@ -114,7 +114,7 @@ anonymizer-streamlit/
 - Navigation par extraits
 
 ### **5. Export Final**
-- **Options** : Filigrane personnalisable, rapport d'audit
+- **Options** : Filigrane personnalisable, rapport d'audit et statistiques détaillées (désactivés par défaut)
 - **Format** : DOCX ou PDF (l'export PDF nécessite le package `fpdf`)
 - **Téléchargement** : Direct depuis l'interface
 

--- a/main.py
+++ b/main.py
@@ -280,10 +280,10 @@ def init_session_state():
         "anonymizer": None,
         "last_file_hash": None,
         "export_options": {
-            "add_watermark": True,
+            "add_watermark": False,
             "watermark_text": "DOCUMENT ANONYMISÉ - CONFORME RGPD",
-            "generate_report": True,
-            "include_statistics": True
+            "generate_report": False,
+            "include_statistics": False
         }
     }
     
@@ -1408,6 +1408,8 @@ def display_export_section_advanced():
             value=st.session_state.export_options["add_watermark"],
             key="export_watermark"
         )
+
+        st.session_state.export_options["add_watermark"] = add_watermark
         
         if add_watermark:
             watermark_text = st.text_input(
@@ -1423,6 +1425,8 @@ def display_export_section_advanced():
             value=st.session_state.export_options["generate_report"],
             key="export_report"
         )
+
+        st.session_state.export_options["generate_report"] = generate_report
         
         # Statistiques
         include_stats = st.checkbox(
@@ -1430,6 +1434,8 @@ def display_export_section_advanced():
             value=st.session_state.export_options["include_statistics"],
             key="export_stats"
         )
+
+        st.session_state.export_options["include_statistics"] = include_stats
         
         # Format d'export
         export_format = st.selectbox(


### PR DESCRIPTION
## Summary
- Set `add_watermark`, `generate_report`, and `include_statistics` defaults to false in session state
- Persist export-option checkbox values back into `session_state`
- Update README to note export features are optional and off by default

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a836f9cc28832d83bdfd206b710860