### PR TITLE
Load false-positive terms from external lists

### DIFF
--- a/src/resources/french_cities.txt
+++ b/src/resources/french_cities.txt
@@ -1,0 +1,7 @@
+Paris
+Lyon
+Marseille
+Le Havre
+La Rochelle
+Saint Pierre
+Notre Dame

--- a/src/resources/legal_terms.txt
+++ b/src/resources/legal_terms.txt
@@ -1,0 +1,4 @@
+Code Civil
+Code Penal
+Cour Supreme
+Tribunal Administratif

--- a/src/resources/professional_titles.txt
+++ b/src/resources/professional_titles.txt
@@ -1,0 +1,6 @@
+Docteur
+Avocat
+Professeur
+Ingenieur
+Notaire
+Maitre


### PR DESCRIPTION
## Summary
- Load false-positive filtering terms from external resource files
- Allow extending city/legal/title lists via environment variables or JSON config
- Filter potential names using word-boundary-aware regex patterns and added tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a83ddfabe0832d832e25fd7dd1d353