### PR TITLE
Add API docs, architecture overview and Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Image de base légère avec Python
+FROM python:3.10-slim
+
+# Définition du répertoire de travail
+WORKDIR /app
+
+# Copie des fichiers de dépendances
+COPY requirements.txt ./
+
+# Installation des dépendances système (si nécessaire) et Python
+# L'option --no-cache-dir réduit la taille de l'image
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+# Copie du reste du code source
+COPY . .
+
+# Exposition du port utilisé par Streamlit
+EXPOSE 8501
+
+# Commande de démarrage par défaut
+CMD ["streamlit", "run", "run.py", "--server.port=8501", "--server.address=0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Cette application Streamlit permet d'anonymiser automatiquement les documents ju
 - 📤 **Export avancé** : DOCX et PDF avec options de filigrane, rapport d'audit et statistiques (désactivées par défaut ; PDF nécessite `fpdf`)
 - 🛡️ **Conformité RGPD** : Standards CNIL respectés
 
+## 📚 Documentation
+
+- [Architecture](docs/architecture.md)
+- [Spécification OpenAPI](docs/openapi.yaml)
+- [Dockerfile](Dockerfile)
+- [Script d'installation](scripts/setup.sh)
+
 ## 🚀 **Installation et Démarrage Rapide**
 
 ### **1. Prérequis**

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,48 @@
+# Architecture du Projet
+
+Ce document décrit l'architecture générale de l'anonymiseur ainsi que les
+interactions principales entre les composants.
+
+## Diagramme de séquence
+
+```mermaid
+sequenceDiagram
+    participant U as Utilisateur
+    participant S as Interface Streamlit
+    participant A as DocumentAnonymizer
+    participant E as EntityManager
+
+    U->>S: Téléverse un document
+    S->>A: `process_document`
+    A-->>S: Entités détectées + texte anonymisé
+    S->>E: Mise à jour des entités
+    E-->>S: Statistiques / Groupes
+    U->>S: Demande d'export
+    S->>A: `export_anonymized_document`
+    A-->>S: Fichier exporté
+    S-->>U: Téléchargement
+```
+
+## Schéma des modules (`src/`)
+
+```mermaid
+graph TD
+    subgraph src
+        A[config.py]
+        B[utils.py]
+        C[anonymizer.py]
+        D[entity_manager.py]
+        E[perf_dashboard.py]
+    end
+
+    A --> C
+    B --> C
+    B --> D
+    C --> E
+```
+
+- **config.py** : Variables de configuration et constantes.
+- **utils.py** : Fonctions utilitaires communes.
+- **anonymizer.py** : Cœur de l'anonymisation (regex et IA).
+- **entity_manager.py** : Gestion et regroupement des entités détectées.
+- **perf_dashboard.py** : Visualisations et métriques de performance.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,117 @@
+openapi: 3.0.3
+info:
+  title: API d'Anonymisation de Documents
+  version: '1.0.0'
+  description: |
+    Spécification des routes pour le service d'anonymisation.
+    Les routes marquées avec `x-planned: true` sont prévues mais non encore
+    implémentées.
+servers:
+  - url: http://localhost:8000
+paths:
+  /health:
+    get:
+      summary: Vérifie l'état du service
+      responses:
+        '200':
+          description: Service opérationnel
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+  /anonymize:
+    post:
+      summary: Anonymise un document fourni
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+                mode:
+                  type: string
+                  description: Méthode de détection
+                  enum: [regex, ai]
+                  default: regex
+                audit:
+                  type: boolean
+                  description: Générer un rapport d'audit
+                  default: false
+      responses:
+        '200':
+          description: Document anonymisé
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  anonymized_text:
+                    type: string
+                  entities:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Entity'
+  /entities:
+    get:
+      summary: Liste les entités détectées lors de la dernière anonymisation
+      x-planned: true
+      responses:
+        '200':
+          description: Tableau des entités détectées
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Entity'
+  /export:
+    post:
+      summary: Exporte un document anonymisé dans un format donné
+      description: Route prévue pour une future fonctionnalité d'export.
+      x-planned: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                document_id:
+                  type: string
+                format:
+                  type: string
+                  enum: [pdf, docx, txt]
+      responses:
+        '200':
+          description: Fichier généré
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+components:
+  schemas:
+    Entity:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        value:
+          type: string
+        start:
+          type: integer
+        end:
+          type: integer
+        confidence:
+          type: number
+      required: [id, type, value]

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Script d'installation automatisée de l'anonymiseur
+# Crée un environnement virtuel et installe les dépendances
+
+set -e
+
+PYTHON=${PYTHON:-python3}
+VENV_DIR=.venv
+
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+    echo "Python3 est requis mais introuvable." >&2
+    exit 1
+fi
+
+# Création de l'environnement virtuel
+if [ ! -d "$VENV_DIR" ]; then
+    "$PYTHON" -m venv "$VENV_DIR"
+fi
+
+# Activation de l'environnement
+# shellcheck disable=SC1090
+source "$VENV_DIR/bin/activate"
+
+pip install --upgrade pip
+pip install -r requirements.txt
+
+echo "Installation terminée. Activez l'environnement avec 'source $VENV_DIR/bin/activate' et lancez 'python run.py'"


### PR DESCRIPTION
## Summary
- document API routes and planned endpoints in `docs/openapi.yaml`
- provide high-level architecture overview with sequence and module diagrams
- add Dockerfile and setup script for reproducible environment and link all docs from README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8624f7934832d98fe1fa4588df991