### PR TITLE
Add group workflow and encoding edge case tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.coverage.run]
+source = ["src"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+fail_under = 85

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -607,6 +607,30 @@ class TestDocumentAnonymizer(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.anonymizer.export_anonymized_document("", None, {"format": "txt"})
 
+    def test_process_document_empty_file(self):
+        """Le traitement d'un fichier vide renvoie une erreur explicite"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            temp_path = f.name
+        try:
+            result = self.anonymizer.process_document(temp_path, mode="regex")
+            self.assertEqual(result["status"], "error")
+            self.assertIn("Aucun texte", result["error"])
+        finally:
+            os.unlink(temp_path)
+
+    def test_extract_text_exotic_encoding(self):
+        """Extraction correcte d'un fichier encodé en latin-1"""
+        content = "Café à Paris"
+        with tempfile.NamedTemporaryFile(mode="wb", suffix=".txt", delete=False) as f:
+            f.write(content.encode("latin-1"))
+            path = f.name
+        try:
+            text, meta = self.anonymizer.document_processor.extract_text_from_txt(path)
+            self.assertEqual(text.strip(), content)
+            self.assertEqual(meta["encoding"], "latin1")
+        finally:
+            os.unlink(path)
+
 class TestIntegration(unittest.TestCase):
     """Tests d'intégration"""
     

--- a/tests/test_entity_manager.py
+++ b/tests/test_entity_manager.py
@@ -1,0 +1,44 @@
+import unittest
+import sys
+from pathlib import Path
+
+# Ajouter le chemin du projet pour les imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.entity_manager import EntityManager
+
+
+class TestGroupManagement(unittest.TestCase):
+    """Tests pour la gestion des groupes dans EntityManager"""
+
+    def setUp(self):
+        self.manager = EntityManager()
+
+    def test_create_update_delete_group(self):
+        """Création, mise à jour puis suppression d'un groupe"""
+        group_id = self.manager.create_group("Test", "desc")
+        self.assertIsNotNone(group_id)
+        group = self.manager.get_group_by_id(group_id)
+        self.assertEqual(group["name"], "Test")
+
+        updated = self.manager.update_group(group_id, {"description": "new"})
+        self.assertTrue(updated)
+        self.assertEqual(self.manager.get_group_by_id(group_id)["description"], "new")
+
+        deleted = self.manager.delete_group(group_id)
+        self.assertTrue(deleted)
+        self.assertIsNone(self.manager.get_group_by_id(group_id))
+
+    def test_filter_entities_by_group(self):
+        """Filtrage d'entités par identifiant de groupe"""
+        group_id = self.manager.create_group("Emails")
+        e1 = self.manager.add_entity({"type": "EMAIL", "value": "a@b.com", "start": 0, "end": 7})
+        e2 = self.manager.add_entity({"type": "EMAIL", "value": "c@d.com", "start": 8, "end": 15})
+        self.manager.add_entity_to_group(group_id, e1)
+        results = self.manager.filter_entities({"group_id": group_id})
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["id"], e1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,48 @@
+import os
+import tempfile
+import unittest
+import sys
+from pathlib import Path
+
+# Ajouter le chemin du projet pour les imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.anonymizer import DocumentAnonymizer
+from docx import Document
+
+
+class TestWorkflowIntegration(unittest.TestCase):
+    """Test d'intégration simulant un upload et un export anonymisé"""
+
+    def test_docx_upload_and_export(self):
+        anonymizer = DocumentAnonymizer()
+        doc = Document()
+        doc.add_paragraph("Email: workflow@example.com")
+
+        with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as tmp:
+            doc.save(tmp.name)
+            docx_path = tmp.name
+
+        try:
+            result = anonymizer.process_document(docx_path, mode="regex")
+            self.assertEqual(result["status"], "success")
+
+            export_path = anonymizer.export_anonymized_document(
+                docx_path, result["entities"], {"format": "txt"}
+            )
+            self.assertTrue(os.path.exists(export_path))
+
+            with open(export_path, "r", encoding="utf-8") as f:
+                content = f.read()
+            self.assertIn("[EMAIL_1]", content)
+            self.assertNotIn("workflow@example.com", content)
+        finally:
+            os.unlink(docx_path)
+            if os.path.exists(result.get("anonymized_path", "")):
+                os.unlink(result["anonymized_path"])
+            if 'export_path' in locals() and os.path.exists(export_path):
+                os.unlink(export_path)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add coverage configuration targeting 85% in pyproject
- expand anonymizer tests for empty files and Latin-1 encoded text
- add group management tests for create/update/delete/filter
- create workflow integration test simulating DOCX upload and export

## Testing
- `pytest`
- `coverage run -m pytest && coverage report` *(fails: total of 38 is less than fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_68a86351b7ec832db94fe1e5a1c351ae