### PR TITLE
feat: normalize personal names before tokenization

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,14 @@
+import unittest
+
+from src.utils import normalize_name
+
+
+class TestNormalizeName(unittest.TestCase):
+    """Tests for the normalize_name utility."""
+
+    def test_remove_title_and_first_name(self):
+        self.assertEqual(normalize_name("Dr Jean Dûpont"), "dupont")
+
+    def test_particles_are_preserved(self):
+        self.assertEqual(normalize_name("Mme de La Tour"), "de la tour")
+


### PR DESCRIPTION
## Summary
- add `normalize_name` utility stripping titles, diacritics and first names while preserving particles
- reuse normalized names in `RegexAnonymizer.anonymize_text` to ensure consistent tokens
- test normalization and token reuse with optional first names and particles

## Testing
- `pip install python-docx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a865b3093c832d8dd0411a103852e6