### PR TITLE
feat: reuse tokens with fuzzy similarity

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,6 +70,7 @@ loguru>=0.7.0,<1.0.0
 regex>=2023.0.0
 unidecode>=1.3.0
 ftfy>=6.1.0  # Correction encodage
+rapidfuzz>=3.0.0
 
 # === OPTIMISATION PERFORMANCE ===
 cachetools>=5.3.0,<6.0.0

--- a/src/utils.py
+++ b/src/utils.py
@@ -78,6 +78,46 @@ def normalize_name(value: str) -> str:
 
     return " ".join(last_parts)
 
+
+def similarity(a: str, b: str, *, score_cutoff: float, algorithm: str = "rapidfuzz") -> bool:
+    """Return ``True`` if the similarity between ``a`` and ``b`` is above ``score_cutoff``.
+
+    Parameters
+    ----------
+    a, b: str
+        Strings to compare.
+    score_cutoff: float
+        Minimum similarity required to return ``True``. The score is expressed
+        between 0 and 1.
+    algorithm: str, optional
+        Either ``"rapidfuzz"`` or ``"levenshtein"`` to select the underlying
+        implementation. ``"rapidfuzz"`` is used by default.
+
+    Returns
+    -------
+    bool
+        ``True`` if the computed similarity is greater than or equal to
+        ``score_cutoff``.
+    """
+
+    if not a or not b:
+        return False
+
+    try:
+        if algorithm == "rapidfuzz":
+            from rapidfuzz import fuzz
+
+            score = fuzz.ratio(a, b) / 100.0
+        else:
+            from Levenshtein import ratio  # type: ignore
+
+            score = ratio(a, b)
+    except ImportError:
+        # If the requested library is missing, the comparison cannot be made
+        return False
+
+    return score >= score_cutoff
+
 def format_file_size(size_bytes: int) -> str:
     """Formater la taille d'un fichier en unités lisibles"""
     if size_bytes == 0:


### PR DESCRIPTION
## Summary
- add `utils.similarity` helper using rapidfuzz or Levenshtein
- allow `RegexAnonymizer` to reuse tokens based on fuzzy matches and expose algorithm & score cutoff
- cover inclusion and misspelling cases with new tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a867a36050832d9ad05241edfa8fe4