### PR TITLE
Optimize token reuse with cached normalization and BK-tree search

### DIFF
--- a/docs/benchmark_results.md
+++ b/docs/benchmark_results.md
@@ -1,0 +1,18 @@
+# Benchmark Results
+
+Benchmark executed with `benchmark.py` on the provided dataset (`data/benchmark`).
+
+| Run | Real time |
+| --- | --- |
+| Before changes | 2.023s |
+| After caching/BK-tree | 2.043s |
+
+Entity-level metrics remained identical after optimizations (excerpt from `benchmark_after.csv`):
+
+```
+entity,precision,recall,f1,support
+DATE,1.0,1.0,1.0,100
+EMAIL,1.0,1.0,1.0,100
+PERSON,0.8571428571428571,1.0,0.9230769230769231,600
+PHONE,1.0,1.0,1.0,100
+```

--- a/src/bktree.py
+++ b/src/bktree.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+from typing import Callable, Dict, List, Optional, Tuple
+
+class _BKTreeNode:
+    def __init__(self, term: str) -> None:
+        self.term = term
+        self.children: Dict[int, _BKTreeNode] = {}
+
+class BKTree:
+    """Simple BK-tree implementation for approximate string matching."""
+
+    def __init__(self, distance_func: Callable[[str, str], int]) -> None:
+        self.distance_func = distance_func
+        self.root: Optional[_BKTreeNode] = None
+
+    def add(self, term: str) -> None:
+        if self.root is None:
+            self.root = _BKTreeNode(term)
+            return
+        node = self.root
+        while True:
+            dist = self.distance_func(term, node.term)
+            child = node.children.get(dist)
+            if child is not None:
+                node = child
+            else:
+                node.children[dist] = _BKTreeNode(term)
+                break
+
+    def search(self, term: str, max_dist: int) -> List[Tuple[str, int]]:
+        if self.root is None:
+            return []
+        results: List[Tuple[str, int]] = []
+        nodes = [self.root]
+        while nodes:
+            node = nodes.pop()
+            dist = self.distance_func(term, node.term)
+            if dist <= max_dist:
+                results.append((node.term, dist))
+            low = dist - max_dist
+            high = dist + max_dist
+            for d, child in node.children.items():
+                if low <= d <= high:
+                    nodes.append(child)
+        return results

--- a/src/entity_manager.py
+++ b/src/entity_manager.py
@@ -97,6 +97,16 @@ class EntityManager:
             # Issues manipulating entity lists are treated as deletion failures
             logging.error(f"Error deleting entity: {str(e)}")
             return False
+
+    def update_token_variants(self, token: str, variant: str) -> None:
+        """Mettre à jour toutes les entités partageant un même jeton."""
+        for entity in self.entities:
+            if entity.get("replacement") == token:
+                variants = set(entity.get("variants", []))
+                if variant not in variants:
+                    variants.add(variant)
+                    entity["variants"] = list(variants)
+                    entity["updated_at"] = datetime.now().isoformat()
     
     def get_entity_by_id(self, entity_id: str) -> Optional[Dict[str, Any]]:
         """Récupérer une entité par son ID"""


### PR DESCRIPTION
## Summary
- cache normalized PERSON values in `RegexAnonymizer`
- switch to BK-tree similarity search when many entries exist
- keep `EntityManager` variants in sync when reusing tokens
- document benchmark results

## Testing
- `pytest`
- `time python benchmark.py --dataset data/benchmark --output benchmark_after.csv`

------
https://chatgpt.com/codex/tasks/task_e_68a877cb33c0832d9f39f3da9494c7dd