### PR TITLE
Expand legal anonymization tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Cette application Streamlit permet d'anonymiser automatiquement les documents ju
 - [Spécification OpenAPI](docs/openapi.yaml)
 - [Dockerfile](Dockerfile)
 - [Script d'installation](scripts/setup.sh)
+- [Guide utilisateur](docs/user_guide.md)
 
 ## 🚀 **Installation et Démarrage Rapide**
 
@@ -192,6 +193,7 @@ Si `rapidfuzz` n'est pas disponible, installez `python-Levenshtein` et sélectio
 pip install python-Levenshtein
 ```
 
+
 ```python
 from src.anonymizer import RegexAnonymizer
 
@@ -201,6 +203,35 @@ anonymizer = RegexAnonymizer(algorithm="levenshtein")
 ```
 
 Dans ce mode, le calcul de similarité repose sur l'algorithme Levenshtein.
+
+## 📈 Tableau de bord juridique
+
+L'interface Streamlit expose un tableau de bord juridique affichant les
+entités détectées, les recommandations et les métriques de performance. Lancez
+l'application avec `python run.py` puis consultez le tableau de bord dans votre
+navigateur à l'adresse indiquée. Les métriques d’anonymisation peuvent être
+visualisées via `perf_dashboard.py`.
+
+## 🛠️ Configuration des templates
+
+Les modèles spécifiques au domaine sont définis dans
+`src/config.py` via la classe `LegalTemplates`. Chaque entrée précise les
+entités à anonymiser, celles à conserver et une liste de mots-clés pour la
+detection automatique. Ajoutez vos propres templates en étendant ce registre.
+
+## 🤖 Intégration Ollama
+
+`OllamaLegalAnalyzer` peut se connecter à un serveur Ollama local pour améliorer
+la classification des documents et la vérification de cohérence. Installez le
+serveur selon la documentation officielle puis lancez-le :
+
+```bash
+curl -fsSL https://ollama.ai/install.sh | sh
+ollama serve
+```
+
+Vous pouvez spécifier l'URL et le modèle Ollama lors de la création de
+`EnhancedDocumentAnonymizer`.
 
 ### **Personnalisation des Entités**
 Modifiez `src/config.py` pour :
@@ -221,3 +252,4 @@ python benchmark.py --dataset data/benchmark --output rapport.csv
 
 Le script génère un fichier CSV contenant précision, rappel et F1 pour
 chaque type d'entité détecté.
+

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,48 @@
+# User Guide
+
+## Legal Dashboard Usage
+
+Launch the Streamlit application to access the legal dashboard:
+
+```bash
+python run.py  # or: streamlit run main.py
+```
+
+The dashboard displays detected entities, template information and
+recommendations. Use the performance dashboard (`perf_dashboard.py`) to
+inspect anonymization metrics.
+
+## Template Configuration
+
+Templates live in `src/config.py` under the `LegalTemplates` registry. Each
+entry defines:
+
+- `entities`: types that must be anonymized.
+- `preserve`: entities that should remain visible.
+- `keywords`: terms used for auto‑detection.
+
+Add new templates by extending `LegalTemplates.LEGAL_TEMPLATES` and provide at
+least a list of keywords.
+
+## Ollama Setup
+
+The `OllamaLegalAnalyzer` optionally connects to a local Ollama server for
+advanced document analysis. Install and start the server:
+
+```bash
+curl -fsSL https://ollama.ai/install.sh | sh
+ollama run llama3  # download a model
+ollama serve       # start the service
+```
+
+Adjust the base URL or model when creating `EnhancedDocumentAnonymizer` or
+`OllamaLegalAnalyzer`:
+
+```python
+from src.enhanced_anonymizer import EnhancedDocumentAnonymizer
+anonymizer = EnhancedDocumentAnonymizer(ollama_base_url="http://localhost:11434", ollama_model="llama3")
+```
+
+If the server is unavailable the application gracefully falls back to regex
+processing.
+

--- a/tests/test_enhanced_anonymizer.py
+++ b/tests/test_enhanced_anonymizer.py
@@ -1,6 +1,7 @@
 import pytest
 
 from src.enhanced_anonymizer import EnhancedDocumentAnonymizer
+from src.config import LegalTemplates
 
 
 def test_process_pipeline_graceful_ollama_unavailable(tmp_path):
@@ -25,3 +26,25 @@ def test_process_pipeline_graceful_ollama_unavailable(tmp_path):
 
     # Compliance report should contain entity counts
     assert result["compliance_report"]["entity_counts"]["EMAIL"] == 1
+
+
+def test_template_detection():
+    text = "Ce contrat de bail lie le bailleur et le locataire"
+    name, tpl = LegalTemplates.detect(text)
+    assert name == "contrat_bail"
+    assert "PERSON" in tpl["entities"]
+
+
+def test_pipeline_selects_template(tmp_path):
+    content = (
+        "Contrat de bail entre le bailleur Jean et le locataire Paul."\
+        " Contact: jean@example.com"
+    )
+    file_path = tmp_path / "bail.txt"
+    file_path.write_text(content, encoding="utf-8")
+
+    anonymizer = EnhancedDocumentAnonymizer()
+    result = anonymizer.process_legal_document(str(file_path))
+
+    assert result["compliance_report"]["template"] == "contrat_bail"
+    assert "[EMAIL_" in result["anonymized_text"]

--- a/tests/test_legal_normalizer.py
+++ b/tests/test_legal_normalizer.py
@@ -34,3 +34,25 @@ class TestLegalEntityNormalizer(unittest.TestCase):
         key = self.normalizer.normalize_person_name("Jean Dupont").canonical
         self.assertIn("M. Jean Dupont", self.normalizer.registry.get(key, set()))
 
+    def test_similarity_zero_for_empty_strings(self) -> None:
+        """Similarity score should be 0.0 when either name is empty."""
+        self.assertEqual(self.normalizer.compute_similarity_score("", ""), 0.0)
+        self.assertEqual(
+            self.normalizer.compute_similarity_score("", "Dupont"), 0.0
+        )
+
+    def test_find_canonical_match_from_registry(self) -> None:
+        """find_canonical_match should search the internal registry by default."""
+        self.normalizer.register_entity_variant("Jean Dupont", "M. Jean Dupont")
+        match = self.normalizer.find_canonical_match("M. Jean Dupont")
+        self.assertIsNotNone(match)
+        self.assertEqual(match.canonical, "jean dupont")
+
+    def test_normalize_person_name_strips_accents_and_titles(self) -> None:
+        """Normalization removes accents and civil titles."""
+        data = self.normalizer.normalize_person_name("Mme José García")
+        self.assertEqual(data.canonical, "jose garcia")
+        # Cache should return the exact same object when called again
+        second = self.normalizer.normalize_person_name("Mme José García")
+        self.assertIs(data, second)
+

--- a/tests/test_ollama_analyzer.py
+++ b/tests/test_ollama_analyzer.py
@@ -1,4 +1,7 @@
 import unittest
+from unittest import mock
+import json
+import requests
 
 from src.ollama_analyzer import OllamaLegalAnalyzer
 
@@ -19,6 +22,70 @@ class TestOllamaAnalyzerFallback(unittest.TestCase):
         suggestion = analyzer.suggest_anonymization_improvements("foo", entities)
         self.assertEqual(
             suggestion, "No suggestions: Ollama server unavailable."
+        )
+
+
+class TestOllamaAnalyzerMockedResponses(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mock_get = mock.patch("requests.get").start()
+        self.mock_get.return_value.raise_for_status.return_value = None
+
+    def tearDown(self) -> None:
+        mock.patch.stopall()
+
+    def _make_response(self, payload):
+        resp = mock.Mock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = payload
+        return resp
+
+    def test_successful_calls(self):
+        mock_post = mock.patch("requests.post").start()
+        mock_post.side_effect = [
+            self._make_response({"response": "contract"}),
+            self._make_response({
+                "response": json.dumps([{"text": "John", "label": "PERSON"}])
+            }),
+            self._make_response(
+                {
+                    "response": json.dumps(
+                        {"coherent": True, "issues": ["none"]}
+                    )
+                }
+            ),
+            self._make_response({"response": "All good."}),
+        ]
+
+        analyzer = OllamaLegalAnalyzer(base_url="http://mock")
+        self.assertTrue(analyzer.is_available)
+
+        doc_type = analyzer.detect_document_type("dummy")
+        self.assertEqual(doc_type, "contract")
+
+        entities = analyzer.enhance_entity_detection(
+            "text", [{"text": "J", "label": "PERSON"}]
+        )
+        self.assertEqual(entities[0]["text"], "John")
+
+        coherence = analyzer.validate_anonymization_coherence("a", "b", entities)
+        self.assertTrue(coherence["coherent"])
+        self.assertEqual(coherence["issues"], ["none"])
+
+        suggestion = analyzer.suggest_anonymization_improvements("foo", entities)
+        self.assertEqual(suggestion, "All good.")
+
+    def test_failure_sets_unavailable(self):
+        mock_post = mock.patch("requests.post").start()
+        mock_post.side_effect = requests.RequestException
+
+        analyzer = OllamaLegalAnalyzer(base_url="http://mock")
+        self.assertTrue(analyzer.is_available)
+
+        self.assertEqual(analyzer.detect_document_type("x"), "unknown")
+        self.assertFalse(analyzer.is_available)
+        self.assertEqual(
+            analyzer.suggest_anonymization_improvements("foo", []),
+            "No suggestions: Ollama server unavailable.",
         )
 
 


### PR DESCRIPTION
## Summary
- add edge-case tests for LegalEntityNormalizer normalization, similarity, and registry matching
- mock Ollama responses to test analyzer methods and fallback logic
- cover template detection and pipeline integration in EnhancedDocumentAnonymizer
- document dashboard usage, template config, and Ollama setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac0ec83a9c832d9d10a3c421286779