### PR TITLE
Exclude common words after French titles

### DIFF
--- a/src/anonymizer.py
+++ b/src/anonymizer.py
@@ -245,7 +245,7 @@ FRENCH_ENTITY_PATTERNS = {
     **ENTITY_PATTERNS,
 
     # Noms français avec titres de civilité
-    "PERSON_FR": r"\b(?:M\.?|Mme\.?|Mlle\.?|Dr\.?|Prof\.?|Me\.?|Maître)\s+[A-ZÀ-Ÿ][a-zà-ÿ]+(?:\s+[A-ZÀ-Ÿ][a-zà-ÿ]+)*",  # Titres de civilité
+    "PERSON_FR": r"\b(?:M\.?|Mme\.?|Mlle\.?|Dr\.?|Prof\.?|Me\.?|Maître)\s+(?!(?:[Ll]e|[Ll]a|[Ll]es|[Pp]résident(?:e)?s?)\b)[A-ZÀ-Ÿ][a-zà-ÿ]+(?:\s+[A-ZÀ-Ÿ][a-zà-ÿ]+)*",  # Titres de civilité
 
     # Organisations françaises spécifiques
     "ORG_FR": r"\b(?:SARL|SAS|SA|SNC|EURL|SASU|SCI|SELARL|SELCA|SELAS|Association|Société|Entreprise|Cabinet|Étude|Bureau|Groupe|Fondation|Institut|Centre|Établissement)\s+[A-ZÀ-Ÿ][A-Za-zÀ-ÿ\s\-'&]+",  # Formes juridiques

--- a/src/config.py
+++ b/src/config.py
@@ -79,7 +79,7 @@ FRENCH_ENTITY_PATTERNS = {
     **ENTITY_PATTERNS,  # Inclure tous les patterns de base
 
     # Noms avec titres de civilité français
-    "PERSON_WITH_TITLE": r"\b(?:M\.?|Mme\.?|Mlle\.?|Dr\.?|Prof\.?|Me\.?|Maître)\s+[A-ZÀ-Ÿ][a-zà-ÿ]+(?:\s+[A-ZÀ-Ÿ][a-zà-ÿ]+)*",  # Titres de civilité
+    "PERSON_WITH_TITLE": r"\b(?:M\.?|Mme\.?|Mlle\.?|Dr\.?|Prof\.?|Me\.?|Maître)\s+(?!(?:[Ll]e|[Ll]a|[Ll]es|[Pp]résident(?:e)?s?)\b)[A-ZÀ-Ÿ][a-zà-ÿ]+(?:\s+[A-ZÀ-Ÿ][a-zà-ÿ]+)*",  # Titres de civilité
 
     # Organisations françaises avec formes juridiques
     "FRENCH_COMPANY": r"\b(?:SARL|SAS|SA|SNC|EURL|SASU|SCI|SELARL|SELCA|SELAS|Association|Société|Entreprise|Cabinet|Étude|Bureau|Groupe|Fondation|Institut|Centre|Établissement)\s+[A-ZÀ-Ÿ][A-Za-zÀ-ÿ\s\-'&]+",  # Formes juridiques françaises

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -55,6 +55,13 @@ class TestRegexAnonymizer(unittest.TestCase):
         date_entities = [e for e in entities if e.type == "DATE"]
         self.assertEqual(len(date_entities), 2)
 
+    def test_common_word_after_title_not_person(self):
+        """Expressions comme 'M. le Président' ne doivent pas être détectées"""
+        text = "M. le Président a parlé."
+        entities = self.anonymizer.detect_entities(text)
+        person_entities = [e for e in entities if e.type == "PERSON"]
+        self.assertEqual(len(person_entities), 0)
+
     def test_date_vs_article_number(self):
         """Les numéros d'article ne doivent pas être détectés comme des dates"""
         text = (


### PR DESCRIPTION
## Summary
- avoid matching common words after French titles when detecting names
- test that phrases like `M. le Président` are no longer tagged as persons

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac205da2fc832d9f45a27a61936109