### PR TITLE
Handle initials in person name matching

### DIFF
--- a/src/legal_normalizer.py
+++ b/src/legal_normalizer.py
@@ -96,7 +96,7 @@ class LegalEntityNormalizer:
         working = "".join(c for c in working if not unicodedata.combining(c))
         working = working.lower()
 
-        tokens = working.split()
+        tokens = re.findall(r"[\w'-]+", working)
         if not tokens:
             result = NormalizedPersonName("", [], "", [])
             self._cache[name] = result
@@ -223,8 +223,19 @@ class LegalEntityNormalizer:
         )
         best_score = 0.0
         best_candidate: Optional[str] = None
+        target_norm = self.normalize_person_name(name)
         for candidate in candidates_iter:
-            score = self.compute_similarity_score(name, candidate)
+            cand_norm = self.normalize_person_name(candidate)
+            if (
+                cand_norm.last_name
+                and cand_norm.last_name == target_norm.last_name
+                and cand_norm.first_names
+                and target_norm.first_names
+                and cand_norm.first_names[0][0] == target_norm.first_names[0][0]
+            ):
+                score = 1.0
+            else:
+                score = self.compute_similarity_score(name, candidate)
             if score > best_score:
                 best_score = score
                 best_candidate = candidate

--- a/tests/test_legal_normalizer.py
+++ b/tests/test_legal_normalizer.py
@@ -29,6 +29,12 @@ class TestLegalEntityNormalizer(unittest.TestCase):
         self.assertIsNotNone(match)
         self.assertEqual(match.canonical, "jean de la fontaine")
 
+    def test_find_canonical_match_with_initial(self) -> None:
+        candidates = ["Jean Dupont", "Paul Durand"]
+        match = self.normalizer.find_canonical_match("J. Dupont", candidates)
+        self.assertIsNotNone(match)
+        self.assertEqual(match.canonical, "jean dupont")
+
     def test_register_entity_variant(self) -> None:
         self.normalizer.register_entity_variant("Jean Dupont", "M. Jean Dupont")
         key = self.normalizer.normalize_person_name("Jean Dupont").canonical


### PR DESCRIPTION
## Summary
- Strip punctuation when tokenizing person names
- Match candidates sharing last name and first-name initial
- Ensure "Jean Dupont" and "J. Dupont" get the same anonymization token

## Testing
- `pytest tests/test_legal_normalizer.py tests/test_anonymizer.py::TestRegexAnonymizer::test_person_token_reuse_with_variants tests/test_anonymizer.py::TestRegexAnonymizer::test_person_token_reuse_with_initials -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac21a66d7c832d89a62376ac55d6a2