### PR TITLE
Improve unicode decoding with chardet and add tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,6 +70,7 @@ loguru>=0.7.0,<1.0.0
 regex>=2023.0.0
 unidecode>=1.3.0
 ftfy>=6.1.0  # Correction encodage
+chardet>=5.0.0  # Détection d'encodage
 rapidfuzz>=3.0.0
 
 # === OPTIMISATION PERFORMANCE ===

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,8 @@
 import os
 import unittest
+from unittest.mock import patch
 
-from src.utils import normalize_name, similarity, get_similarity_weights
+from src.utils import normalize_name, similarity, get_similarity_weights, ensure_unicode
 
 
 class TestNormalizeName(unittest.TestCase):
@@ -38,4 +39,18 @@ class TestSimilarity(unittest.TestCase):
             self.assertAlmostEqual(sum(weights.values()), 1.0)
         finally:
             del os.environ["ANONYMIZER_SIMILARITY_WEIGHTS"]
+
+
+class TestEnsureUnicode(unittest.TestCase):
+    """Tests for the ensure_unicode utility."""
+
+    def test_preserves_accented_characters(self):
+        data = "Café".encode("utf-8")
+        self.assertEqual(ensure_unicode(data), "Café")
+
+    def test_raises_on_unknown_encoding(self):
+        bad_bytes = b"\xff\xfe\xfd"
+        with patch("src.utils.chardet.detect", return_value={"encoding": None, "confidence": 0}):
+            with self.assertRaises(UnicodeDecodeError):
+                ensure_unicode(bad_bytes)
 


### PR DESCRIPTION
## Summary
- detect text encoding with chardet and raise on failure
- add unit tests for ensure_unicode and include chardet dependency

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac22f081c4832dba5f5e7d3d0ad975