### PR TITLE
fix: provide hidden label for variant selection checkbox

### DIFF
--- a/src/variant_manager_ui.py
+++ b/src/variant_manager_ui.py
@@ -158,7 +158,12 @@ def display_variant_management(group: Dict[str, Any], manager: VariantManager) -
     for idx, variant in enumerate(group.get("variants", [])):
         col1, col2, col3, col4 = st.columns([1, 3, 2, 2])
         with col1:
-            if st.checkbox("", value=True, key=f"sel_{group['id']}_{idx}"):
+            if st.checkbox(
+                "Sélection",
+                value=True,
+                key=f"sel_{group['id']}_{idx}",
+                label_visibility="hidden",
+            ):
                 selected.append(variant)
         with col2:
             st.write(f"**{variant['value']}** ({variant.get('count', 0)} occ.)")


### PR DESCRIPTION
## Summary
- ensure selection checkbox in variant manager has accessible label

## Testing
- `python - <<'PY'
from streamlit.testing.v1 import AppTest
AppTest.from_file('/tmp/test_app2.py').run()
print('done')
PY`
- `pytest tests/test_entity_manager.py -q`
- `python -m pytest tests/test_utils.py -q` *(fails: TestSimilarity.test_env_threshold)*

------
https://chatgpt.com/codex/tasks/task_e_68ac522b9a78832daf250835b13fd5a0