### PR TITLE
Replace Streamlit experimental reruns with rerun

### DIFF
--- a/src/streamlit_legal_ui.py
+++ b/src/streamlit_legal_ui.py
@@ -97,7 +97,7 @@ def display_legal_entity_manager(
             display_variant_management(group, manager)
             if st.button("\u2b05\ufe0f Retour", key=f"back_{group['id']}"):
                 st.session_state[f"show_details_{group['id']}"] = False
-                st.experimental_rerun()
+                st.rerun()
             st.write("---")
 
     delete_id = st.session_state.get("delete_group")
@@ -105,6 +105,6 @@ def display_legal_entity_manager(
         del manager.groups[delete_id]
         st.session_state.pop("delete_group", None)
         groups[:] = list(manager.groups.values())
-        st.experimental_rerun()
+        st.rerun()
 
     groups[:] = list(manager.groups.values())

--- a/src/variant_management_ui.py
+++ b/src/variant_management_ui.py
@@ -114,11 +114,11 @@ def display_variant_editor(
             if st.button("✅ Confirmer", key=f"conf_{group_id}_{variant_index}"):
                 manager.modify_variant(group_id, variant["value"], new_value)
                 st.session_state[key] = False
-                st.experimental_rerun()
+                st.rerun()
         with col2:
             if st.button("❌ Annuler", key=f"cancel_{group_id}_{variant_index}"):
                 st.session_state[key] = False
-                st.experimental_rerun()
+                st.rerun()
 
 
 def display_variant_management(group: Dict[str, Any], manager: VariantManager) -> None:
@@ -155,7 +155,7 @@ def display_variant_management(group: Dict[str, Any], manager: VariantManager) -
         with col4:
             if st.button("🗑️ Exclure", key=f"exclude_{group['id']}_{i}"):
                 manager.exclude_variant(group["id"], variant["value"])
-                st.experimental_rerun()
+                st.rerun()
             suggestion = get_smart_suggestion(variant)
             if suggestion and st.button(
                 f"💡 {suggestion['action']}", key=f"suggest_{group['id']}_{i}"
@@ -163,7 +163,7 @@ def display_variant_management(group: Dict[str, Any], manager: VariantManager) -
                 manager.modify_variant(
                     group["id"], variant["value"], suggestion["new_value"]
                 )
-                st.experimental_rerun()
+                st.rerun()
 
         display_variant_editor(group["id"], i, variant, manager)
 
@@ -175,7 +175,7 @@ def display_variant_management(group: Dict[str, Any], manager: VariantManager) -
         with col1:
             if st.button("📝 Nouveau groupe", key=f"new_group_{group['id']}"):
                 manager.create_new_group_from_variants(selected_variants)
-                st.experimental_rerun()
+                st.rerun()
 
         with col2:
             target = st.selectbox(
@@ -188,13 +188,13 @@ def display_variant_management(group: Dict[str, Any], manager: VariantManager) -
                     g["id"] for g in manager.groups.values() if g["token"] == target
                 ][0]
                 manager.groups[target_id]["variants"].extend(selected_variants)
-                st.experimental_rerun()
+                st.rerun()
 
         with col3:
             if st.button("🗑️ Supprimer sélection", key=f"del_sel_{group['id']}"):
                 for v in selected_variants:
                     manager.exclude_variant(group["id"], v["value"])
-                st.experimental_rerun()
+                st.rerun()
 
 
 def display_entity_group_compact(group: Dict[str, Any]) -> None:

--- a/src/variant_manager_ui.py
+++ b/src/variant_manager_ui.py
@@ -186,24 +186,24 @@ def display_variant_management(group: Dict[str, Any], manager: VariantManager) -
                     if st.button("✅", key=f"save_{group['id']}_{idx}"):
                         manager.update_variant(group["id"], variant["value"], new_val)
                         st.session_state[state_key] = False
-                        st.experimental_rerun()
+                        st.rerun()
                 with c2:
                     if st.button("❌", key=f"cancel_{group['id']}_{idx}"):
                         st.session_state[state_key] = False
-                        st.experimental_rerun()
+                        st.rerun()
             if st.button("🔍 Contextes", key=f"ctx_{group['id']}_{idx}"):
                 with st.expander("Contextes"):
                     st.write(f"... {variant['value']} ...")
         with col4:
             if st.button("🗑️ Exclure", key=f"ex_{group['id']}_{idx}"):
                 manager.exclude_variant(group["id"], variant["value"])
-                st.experimental_rerun()
+                st.rerun()
             suggestion = _suggest_short_form(variant["value"])
             if suggestion and st.button(
                 f"💡 {suggestion['action']}", key=f"sugg_{group['id']}_{idx}"
             ):
                 manager.update_variant(group["id"], variant["value"], suggestion["new_value"])
-                st.experimental_rerun()
+                st.rerun()
 
     if selected:
         st.write("---")
@@ -222,15 +222,15 @@ def display_variant_management(group: Dict[str, Any], manager: VariantManager) -
                 manager.merge_variants(
                     group["id"], target_id, [v["value"] for v in selected]
                 )
-                st.experimental_rerun()
+                st.rerun()
         with col2:
             if st.button("🗑️ Supprimer sélection", key=f"del_sel_{group['id']}"):
                 for v in selected:
                     manager.exclude_variant(group["id"], v["value"])
-                st.experimental_rerun()
+                st.rerun()
 
     st.write("---")
     new_variant = st.text_input("Ajouter une variante", key=f"new_var_{group['id']}")
     if st.button("Ajouter", key=f"add_var_{group['id']}") and new_variant:
         manager.add_variant(group["id"], new_variant, [])
-        st.experimental_rerun()
+        st.rerun()


### PR DESCRIPTION
## Summary
- Replace deprecated `st.experimental_rerun()` with `st.rerun()` in variant and legal UI modules
- Ensure Streamlit group management actions rely on stable rerun API

## Testing
- `PYTHONPATH=. pytest tests/test_entity_manager.py -q`
- `PYTHONPATH=. pytest tests/test_utils.py -q` *(fails: similarity threshold assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5b61d270832d92215497f9f5dd41