### PR TITLE
Refactor legal entity manager with helper utilities

### DIFF
--- a/src/group_ui_utils.py
+++ b/src/group_ui_utils.py
@@ -1,0 +1,60 @@
+"""Utility functions for managing group-related UI state.
+
+These helpers encapsulate the core logic for filtering groups and handling
+selection or deletion actions so that it can be tested independently from the
+Streamlit interface.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from .variant_manager_ui import VariantManager
+
+
+def filter_groups(groups: Dict[int, Dict[str, Any]], search_term: str) -> Dict[int, Dict[str, Any]]:
+    """Return a subset of ``groups`` whose token contains ``search_term``.
+
+    Parameters
+    ----------
+    groups:
+        Mapping of group identifiers to group dictionaries.
+    search_term:
+        Term used to filter groups by their ``token`` field. The comparison is
+        case-insensitive.
+    """
+    term = search_term.lower()
+    return {gid: g for gid, g in groups.items() if term in g.get("token", "").lower()}
+
+
+def mark_groups_for_management(session_state: Dict[str, Any], group_ids: Iterable[int]) -> None:
+    """Mark ``group_ids`` to display their management interface.
+
+    This updates ``session_state`` so that the details for the given groups are
+    shown and any existing selection checkboxes are cleared.
+    """
+    for gid in group_ids:
+        gid_str = str(gid)
+        session_state[f"show_details_{gid_str}"] = True
+        session_state[f"manage_{gid_str}"] = False
+        session_state[f"delete_{gid_str}"] = False
+
+
+def delete_groups(
+    manager: "VariantManager",
+    groups: List[Dict[str, Any]],
+    session_state: Dict[str, Any],
+    group_ids: Iterable[int],
+) -> None:
+    """Remove groups identified by ``group_ids`` from the manager.
+
+    The provided ``groups`` list is updated in-place to reflect the current
+    state of ``manager``. Related keys are removed from ``session_state``.
+    """
+    for gid in group_ids:
+        gid_str = str(gid)
+        manager.groups.pop(gid, None)
+        session_state.pop(f"manage_{gid_str}", None)
+        session_state.pop(f"delete_{gid_str}", None)
+        session_state.pop(f"show_details_{gid_str}", None)
+    groups[:] = list(manager.groups.values())

--- a/src/streamlit_legal_ui.py
+++ b/src/streamlit_legal_ui.py
@@ -7,6 +7,7 @@ from src.variant_manager_ui import (
     display_entity_group_compact,
     display_variant_management,
 )
+from src.group_ui_utils import filter_groups, mark_groups_for_management, delete_groups
 from src.entity_manager import EntityManager
 
 
@@ -62,11 +63,7 @@ def display_legal_entity_manager(
     # Search field to filter groups by token
     search_term = st.text_input("Rechercher un groupe", "").lower()
 
-    filtered_groups = {
-        gid: g
-        for gid, g in manager.groups.items()
-        if search_term in g.get("token", "").lower()
-    }
+    filtered_groups = filter_groups(manager.groups, search_term)
 
     # Header for the table
     header_cols = st.columns([3, 2, 1, 1])
@@ -111,19 +108,11 @@ def display_legal_entity_manager(
     # Bulk operation buttons
     bulk_cols = st.columns(2)
     if bulk_cols[0].button("Gérer la sélection", disabled=not selected_manage):
-        for gid in selected_manage:
-            st.session_state[f"show_details_{gid}"] = True
-            st.session_state[f"manage_{gid}"] = False
-            st.session_state[f"delete_{gid}"] = False
+        mark_groups_for_management(st.session_state, selected_manage)
         st.rerun()
 
     if bulk_cols[1].button("Supprimer la sélection", disabled=not selected_delete):
-        for gid in selected_delete:
-            manager.groups.pop(gid, None)
-            st.session_state.pop(f"manage_{gid}", None)
-            st.session_state.pop(f"delete_{gid}", None)
-            st.session_state.pop(f"show_details_{gid}", None)
-        groups[:] = list(manager.groups.values())
+        delete_groups(manager, groups, st.session_state, selected_delete)
         st.rerun()
 
     # Show variant management for selected groups

--- a/tests/test_group_ui_utils.py
+++ b/tests/test_group_ui_utils.py
@@ -1,0 +1,46 @@
+import pytest
+
+from src.group_ui_utils import filter_groups, mark_groups_for_management, delete_groups
+
+
+def test_filter_groups():
+    groups = {
+        1: {"id": 1, "token": "Alpha"},
+        2: {"id": 2, "token": "Beta"},
+        3: {"id": 3, "token": "Gamma"},
+    }
+    assert list(filter_groups(groups, "alp").keys()) == [1]
+    assert set(filter_groups(groups, "a").keys()) == {1, 2, 3}
+    assert list(filter_groups(groups, "z").keys()) == []
+
+
+def test_mark_groups_for_management():
+    session_state = {}
+    mark_groups_for_management(session_state, [1, 2])
+    assert session_state["show_details_1"] is True
+    assert session_state["show_details_2"] is True
+    assert session_state["manage_1"] is False
+    assert session_state["delete_2"] is False
+
+
+def test_delete_groups():
+    groups_list = [
+        {"id": 1, "token": "Alpha"},
+        {"id": 2, "token": "Beta"},
+    ]
+
+    class DummyManager:
+        def __init__(self, groups):
+            self.groups = {g["id"]: g for g in groups}
+
+    manager = DummyManager(groups_list.copy())
+    session_state = {
+        "manage_1": True,
+        "delete_1": True,
+        "show_details_1": True,
+    }
+    delete_groups(manager, groups_list, session_state, [1])
+    assert 1 not in manager.groups
+    assert groups_list == [{"id": 2, "token": "Beta"}]
+    assert "manage_1" not in session_state
+    assert "show_details_1" not in session_state


### PR DESCRIPTION
## Summary
- extract group filtering and selection logic into `group_ui_utils`
- use helper functions in `display_legal_entity_manager` to simplify UI
- add unit tests for group filtering, management marks, and deletion

## Testing
- `PYTHONPATH=. pytest tests/test_group_ui_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac6a00f020832dbc3f86c8f5c4a251