### PR TITLE
Default type filters to include all groups

### DIFF
--- a/src/streamlit_legal_ui.py
+++ b/src/streamlit_legal_ui.py
@@ -89,8 +89,10 @@ def display_legal_entity_manager(
     filters = st.session_state["group_filters"]
     filters["query"] = st.text_input(texts["search_group"], filters.get("query", ""))
     type_options = sorted({g.get("type", "") for g in groups if g.get("type")})
+    if not filters.get("types"):
+        filters["types"] = type_options
     filters["types"] = st.multiselect(
-        texts["table_type"], type_options, default=filters.get("types", [])
+        texts["table_type"], type_options, default=filters["types"]
     )
     st.session_state["group_filters"] = filters
 


### PR DESCRIPTION
## Summary
- Initialize group type filters to include all available types when unset
- Pass saved types to Streamlit multiselect
- Cover default behavior in unit tests

## Testing
- `pytest tests/test_streamlit_group_ui.py::test_filters_types_defaults_to_all -q`
- `pytest -q` *(fails: AssertionError in anonymizer & utils tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ac78f95bbc832d8d488947b8849cf1