### PR TITLE
Preserve group identifiers in grouped entity data

### DIFF
--- a/main.py
+++ b/main.py
@@ -1210,7 +1210,8 @@ def display_groups_tab_advanced():
             else:
                 st.warning("Veuillez renseigner un nom et sélectionner des entités.")
     
-    groups = list(st.session_state.entity_manager.get_grouped_entities().values())
+    grouped = st.session_state.entity_manager.get_grouped_entities()
+    groups = [{"id": gid, **data} for gid, data in grouped.items()]
     display_legal_entity_manager(
         groups, entity_manager=st.session_state.entity_manager, language="fr"
     )

--- a/src/entity_manager.py
+++ b/src/entity_manager.py
@@ -148,6 +148,7 @@ class EntityManager:
             group = grouped.setdefault(
                 group_id,
                 {
+                    "id": group_id,
                     "type": entity.get("type"),
                     "token": token,
                     "total_occurrences": 0,


### PR DESCRIPTION
## Summary
- Keep group identifiers when displaying grouped entities in `display_groups_tab_advanced`
- Embed group IDs directly in grouped entity data returned by `EntityManager.get_grouped_entities`

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac7a8b9844832d8a82d0ed4317577d