### PR TITLE
fix: add checkbox label to avoid warning

### DIFF
--- a/src/streamlit_legal_ui.py
+++ b/src/streamlit_legal_ui.py
@@ -151,7 +151,12 @@ def display_legal_entity_manager(
     for g in page_groups:
         gid = g.get("id")
         cols = st.columns([0.5, 2, 1, 1, 2, 2])
-        checked = cols[0].checkbox("", value=gid in selected, key=f"sel_{gid}")
+        checked = cols[0].checkbox(
+            "Sélectionner",
+            value=gid in selected,
+            key=f"sel_{gid}",
+            label_visibility="collapsed",
+        )
         if checked and gid not in selected:
             selected.append(gid)
         if not checked and gid in selected:


### PR DESCRIPTION
## Summary
- use a hidden "Sélectionner" label on group selection checkboxes to avoid Streamlit empty-label warnings

## Testing
- `streamlit run tmp_checkbox.py --server.headless true`
- `pytest` *(fails: tests/test_anonymizer.py::TestRegexAnonymizer::test_overlapping_entities, tests/test_anonymizer.py::TestRegexAnonymizer::test_token_reuse_and_counter_reset, tests/test_anonymizer.py::TestRegexAnonymizer::test_token_reuse_with_inclusion, tests/test_anonymizer.py::TestRegexAnonymizer::test_token_reuse_with_inclusion_reverse_order, tests/test_utils.py::TestSimilarity::test_env_threshold)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7bba498c832db3a7e176c6e64b7c