### PR TITLE
Add Streamlit TextColumn parameter validation and extra kwarg regression test

### DIFF
--- a/tests/test_streamlit_group_ui.py
+++ b/tests/test_streamlit_group_ui.py
@@ -64,9 +64,12 @@ class FakeStreamlit:
         self.columns_index = 0
         self.session_state = {}
         self.data_editor_updates = data_editor_updates or {}
+        def text_column(label=None, *, help=None, width=None, max_chars=None, validate=None):
+            return None
+
         self.column_config = types.SimpleNamespace(
             CheckboxColumn=lambda *a, **k: None,
-            TextColumn=lambda *a, **k: None,
+            TextColumn=text_column,
         )
 
     def header(self, *a, **k):
@@ -138,3 +141,8 @@ def test_filters_types_defaults_to_all(monkeypatch):
     streamlit_legal_ui.display_legal_entity_manager(groups, language="en")
     assert st.multiselect_last_default == ["PERSON"]
     assert st.session_state["group_filters"]["types"] == ["PERSON"]
+
+
+def test_display_legal_entity_manager_rejects_extra_kwargs():
+    with pytest.raises(TypeError):
+        streamlit_legal_ui.display_legal_entity_manager([], language="en", unexpected=True)


### PR DESCRIPTION
## Summary
- Replace `TextColumn` lambda stub with function mirroring Streamlit's parameters to raise `TypeError` on unexpected keywords.
- Add regression test ensuring `display_legal_entity_manager` rejects unsupported keyword arguments.

## Testing
- `pytest -q tests/test_streamlit_group_ui.py`
- `pytest -q` *(fails: AssertionError in anonymizer and utils tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7a1e8adc832db262b7d04cd2cca4