### PR TITLE
feat: delete token-based entity groups

### DIFF
--- a/src/streamlit_legal_ui.py
+++ b/src/streamlit_legal_ui.py
@@ -202,11 +202,12 @@ def display_legal_entity_manager(
             selected.discard(gid)
     st.session_state["selected_for_delete"] = selected
 
-    if st.button("Valider suppression", disabled=not selected):
+    confirm_cols = st.columns(2)
+    if confirm_cols[0].button("Valider suppression", disabled=not selected):
         ids_to_delete = st.session_state["selected_for_delete"]
         if entity_manager:
             for gid in ids_to_delete:
-                entity_manager.delete_group(gid)
+                entity_manager.delete_group_by_token(gid)
             groups[:] = list(entity_manager.get_grouped_entities().values())
         else:
             groups[:] = [g for g in groups if g.get("id") not in ids_to_delete]

--- a/tests/test_entity_manager.py
+++ b/tests/test_entity_manager.py
@@ -169,6 +169,17 @@ class TestGroupManagement(unittest.TestCase):
         self.assertEqual(rep_map["Al"], "[PERSON_1]")
         self.assertEqual(rep_map["Bob"], "[PERSON_1]")
 
+    def test_delete_group_by_token(self):
+        self.manager.add_entity({"type": "PERSON", "value": "Alice", "start": 0, "end": 5, "replacement": "[PERSON_1]"})
+        self.manager.add_entity({"type": "PERSON", "value": "Bob", "start": 6, "end": 9, "replacement": "[PERSON_1]"})
+        self.manager.add_entity({"type": "PERSON", "value": "Eve", "start": 10, "end": 13, "replacement": "[PERSON_2]"})
+        self.manager.get_grouped_entities()
+        deleted = self.manager.delete_group_by_token("PERSON_1")
+        self.assertEqual(deleted, 2)
+        self.assertEqual(len(self.manager.entities), 1)
+        self.assertEqual(self.manager.entities[0]["value"], "Eve")
+        self.assertIsNone(self.manager._grouped_entities_cache)
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/tests/test_streamlit_group_ui.py
+++ b/tests/test_streamlit_group_ui.py
@@ -131,8 +131,28 @@ def test_delete_action_removes_group(monkeypatch):
     assert groups == []
 
 
+def test_delete_action_uses_entity_manager(monkeypatch):
+    cols = [
+        [FakeColumn(), FakeColumn(), FakeColumn()],
+        [FakeColumn(button=True), FakeColumn(button=False)],
+    ]
+    st = FakeStreamlit(columns_sets=cols, data_editor_updates={0: {"Delete": True}})
+    monkeypatch.setattr(streamlit_legal_ui, "st", st)
+    em = streamlit_legal_ui.EntityManager()
+    em.add_entity({"type": "PERSON", "value": "Alice", "start": 0, "end": 5, "replacement": "[Alpha]"})
+    em.add_entity({"type": "PERSON", "value": "Bob", "start": 6, "end": 9, "replacement": "[Beta]"})
+    groups = list(em.get_grouped_entities().values())
+    streamlit_legal_ui.display_legal_entity_manager(groups, entity_manager=em, language="en")
+    assert len(em.entities) == 1
+    assert em.entities[0]["replacement"] == "[Beta]"
+    assert groups == list(em.get_grouped_entities().values())
+
+
 def test_filters_types_defaults_to_all(monkeypatch):
-    cols = [[FakeColumn(), FakeColumn(), FakeColumn()]]
+    cols = [
+        [FakeColumn(), FakeColumn(), FakeColumn()],
+        [FakeColumn(), FakeColumn()],
+    ]
     st = FakeStreamlit(columns_sets=cols)
     monkeypatch.setattr(streamlit_legal_ui, "st", st)
     groups = [


### PR DESCRIPTION
## Summary
- add `delete_group_by_token` to remove all entities sharing a replacement token and clear caches
- call new deletion helper from UI bulk deletion handler
- cover token-based deletion via new tests

## Testing
- `pytest tests/test_streamlit_group_ui.py -q`
- `pytest tests/test_entity_manager.py -q`
- `pytest -q` *(fails: TestRegexAnonymizer::test_token_reuse_and_counter_reset, TestRegexAnonymizer::test_token_reuse_with_inclusion, TestRegexAnonymizer::test_token_reuse_with_inclusion_reverse_order, TestSimilarity::test_env_threshold)*

------
https://chatgpt.com/codex/tasks/task_e_68ad84c40c7c832db21a627254302f48