### PR TITLE
Handle multiple deletions without rerun in Streamlit UI

### DIFF
--- a/src/streamlit_legal_ui.py
+++ b/src/streamlit_legal_ui.py
@@ -203,7 +203,6 @@ def display_legal_entity_manager(
             texts["table_variants"],
         ],
     )
-    initial_selected = set(selected)
 
     edit_ids = edited_df.loc[edited_df[texts["action_edit"]], "id"]
     if not edit_ids.empty:
@@ -218,9 +217,6 @@ def display_legal_entity_manager(
         edited_df.loc[~edited_df[texts["action_delete"]], "id"]
     )
     st.session_state["selected_for_delete"] = selected
-
-    if selected != initial_selected:
-        st.rerun()
 
     confirm_cols = st.columns(2)
     if confirm_cols[0].button("Valider suppression", disabled=not selected):


### PR DESCRIPTION
## Summary
- Remove rerun trigger when updating selected entities for deletion
- Keep deletion button using `st.session_state["selected_for_delete"]` to remove groups in bulk

## Testing
- `pytest -q` *(fails: '[NAME_2] and [NAME_1]' != '[NAME_2] and [NAME_3]' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b1935c3a90832d8c5c9abbbab5aeb4