### PR TITLE
Update delete confirmation button label

### DIFF
--- a/src/streamlit_legal_ui.py
+++ b/src/streamlit_legal_ui.py
@@ -202,7 +202,7 @@ def display_legal_entity_manager(
                 texts["table_variants"],
             ],
         )
-        submitted = st.form_submit_button("Valider suppression")
+        submitted = st.form_submit_button("Valider")
 
     edit_ids = edited_df.loc[edited_df[texts["action_edit"]], "id"]
     if not edit_ids.empty:


### PR DESCRIPTION
## Summary
- Simplify the entity group delete form submit button label to "Valider"

## Testing
- `pytest -q` *(fails: `AssertionError` in several tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b1be5f9b78832db95cf52a5905faa2