### PR TITLE
feat: support custom export paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,10 +141,15 @@ anonymizer = DocumentAnonymizer()
 result = anonymizer.process_document("contrat.pdf", audit=True)
 
 # Export en incluant le rapport
-export_path = anonymizer.export_anonymized_document(
+export_paths = anonymizer.export_anonymized_document(
     "contrat.txt", options={"format": "txt"}, audit=True
 )
+print("Chemin temporaire:", export_paths["temp_path"])
+print("Chemin final:", export_paths["output_path"])
 ```
+
+> 💡 Pour enregistrer une copie dans un dossier spécifique sans modifier le
+> fichier source, utilisez l'option `options={"format": "txt", "output_path": "/chemin/personnalise"}`.
 
 ## ⚙️ **Configuration Avancée**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ sequenceDiagram
     E-->>S: Statistiques / Groupes
     U->>S: Demande d'export
     S->>A: `export_anonymized_document`
-    A-->>S: Fichier exporté
+    A-->>S: Chemins d'export (temp + final)
     S-->>U: Téléchargement
 ```
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -27,12 +27,15 @@ class TestWorkflowIntegration(unittest.TestCase):
             result = anonymizer.process_document(docx_path, mode="regex")
             self.assertEqual(result["status"], "success")
 
-            export_path = anonymizer.export_anonymized_document(
+            export_result = anonymizer.export_anonymized_document(
                 docx_path, result["entities"], {"format": "txt"}
             )
-            self.assertTrue(os.path.exists(export_path))
+            output_path = export_result["output_path"]
+            temp_path = export_result["temp_path"]
+            self.assertTrue(os.path.exists(output_path))
+            self.assertTrue(os.path.exists(temp_path))
 
-            with open(export_path, "r", encoding="utf-8") as f:
+            with open(temp_path, "r", encoding="utf-8") as f:
                 content = f.read()
             self.assertIn("[EMAIL_1]", content)
             self.assertNotIn("workflow@example.com", content)
@@ -40,8 +43,10 @@ class TestWorkflowIntegration(unittest.TestCase):
             os.unlink(docx_path)
             if os.path.exists(result.get("anonymized_path", "")):
                 os.unlink(result["anonymized_path"])
-            if 'export_path' in locals() and os.path.exists(export_path):
-                os.unlink(export_path)
+            if 'export_result' in locals():
+                for path in {export_result.get("output_path"), export_result.get("temp_path")}:
+                    if path and os.path.exists(path):
+                        os.unlink(path)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- return both temporary and final export paths and allow copying to a user-specified destination
- expose the custom export option in the Streamlit UI and surface the resulting location to users
- document the new behaviour and extend unit and workflow tests to cover custom export paths

## Testing
- pytest tests/test_anonymizer.py tests/test_workflow.py


------
https://chatgpt.com/codex/tasks/task_e_68e4ba25e8d8832d83cc8faf49967a65