### PR TITLE
Fix entity group creation to update entity replacements

### DIFF
--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -376,10 +376,11 @@ class TestEntityManager(unittest.TestCase):
             "Emails test",
             "Groupe de test pour les emails"
         )
-        
+
         self.assertIsNotNone(group_id)
         group = self.manager.get_group_by_id(group_id)
         self.assertEqual(group["name"], "Emails test")
+        self.assertTrue(group["token"].startswith("[EMAILS_TEST"))
     
     def test_group_entities(self):
         """Test de groupement d'entités"""

--- a/tests/test_entity_manager.py
+++ b/tests/test_entity_manager.py
@@ -20,6 +20,7 @@ class TestGroupManagement(unittest.TestCase):
         self.assertIsNotNone(group_id)
         group = self.manager.get_group_by_id(group_id)
         self.assertEqual(group["name"], "Test")
+        self.assertEqual(group["token"], "[TEST]")
 
         updated = self.manager.update_group(group_id, {"description": "new"})
         self.assertTrue(updated)
@@ -38,6 +39,19 @@ class TestGroupManagement(unittest.TestCase):
         results = self.manager.filter_entities({"group_id": group_id})
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["id"], e1)
+
+    def test_create_group_assigns_replacement(self):
+        """Les entités sélectionnées doivent recevoir le nouveau token."""
+        entity_id = self.manager.add_entity(
+            {"type": "ORG", "value": "Acme", "start": 0, "end": 4}
+        )
+        group_id = self.manager.create_group("Mon Groupe", entity_ids=[entity_id])
+
+        entity = self.manager.get_entity_by_id(entity_id)
+        self.assertEqual(entity["replacement"], "[MON_GROUPE]")
+        grouped = self.manager.get_grouped_entities()
+        self.assertIn(group_id, grouped)
+        self.assertEqual(grouped[group_id]["token"], "[MON_GROUPE]")
 
     def test_get_grouped_entities(self):
         """Vérifie la création correcte des groupes d'entités."""


### PR DESCRIPTION
## Summary
- generate deterministic group identifiers and tokens when creating groups and assign them to selected entities
- restore previous entity replacements when undoing a group creation to keep the cache and history consistent
- extend tests to cover the new token assignment logic

## Testing
- pytest tests/test_entity_manager.py tests/test_anonymizer.py *(fails: missing fr_core_news_lg spaCy model and existing tokenizer expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68e617f0fc74832da0a8003c0fb63af7