### PR TITLE
Fix grouped occurrence counting

### DIFF
--- a/src/entity_manager.py
+++ b/src/entity_manager.py
@@ -157,17 +157,31 @@ class EntityManager:
                 },
             )
 
-            group["total_occurrences"] += 1
+            occurrences = int(entity.get("total_occurrences") or 1)
+            if occurrences < 1:
+                occurrences = 1
+            group["total_occurrences"] += occurrences
 
             value = entity.get("value")
             variant_entry = group["variants"].setdefault(
                 value,
                 {"value": value, "count": 0, "positions": []},
             )
-            variant_entry["count"] += 1
-            variant_entry["positions"].append(
-                {"start": entity.get("start"), "end": entity.get("end")}
-            )
+            variant_entry["count"] += occurrences
+
+            positions = entity.get("all_positions") or []
+            if positions:
+                for pos in positions:
+                    if isinstance(pos, dict):
+                        start = pos.get("start")
+                        end = pos.get("end")
+                    else:
+                        start, end = pos
+                    variant_entry["positions"].append({"start": start, "end": end})
+            else:
+                variant_entry["positions"].append(
+                    {"start": entity.get("start"), "end": entity.get("end")}
+                )
 
         self._grouped_entities_cache = grouped
         return grouped

--- a/tests/test_entity_manager.py
+++ b/tests/test_entity_manager.py
@@ -96,6 +96,39 @@ class TestGroupManagement(unittest.TestCase):
         self.assertEqual(org_group["total_occurrences"], 1)
         self.assertIn("Acme", org_group["variants"])
 
+    def test_grouped_entities_use_total_occurrences_metadata(self):
+        """Les occurrences agrégées doivent être prises en compte."""
+
+        self.manager.add_entity(
+            {
+                "type": "EMAIL",
+                "value": "john.doe@example.com",
+                "start": 0,
+                "end": 20,
+                "replacement": "[EMAIL_1]",
+                "total_occurrences": 3,
+                "all_positions": [(0, 20), (30, 50), (60, 80)],
+            }
+        )
+
+        grouped = self.manager.get_grouped_entities()
+
+        self.assertIn("EMAIL_1", grouped)
+        email_group = grouped["EMAIL_1"]
+        self.assertEqual(email_group["total_occurrences"], 3)
+
+        variant = email_group["variants"]["john.doe@example.com"]
+        self.assertEqual(variant["count"], 3)
+        self.assertEqual(len(variant["positions"]), 3)
+        self.assertEqual(
+            variant["positions"],
+            [
+                {"start": 0, "end": 20},
+                {"start": 30, "end": 50},
+                {"start": 60, "end": 80},
+            ],
+        )
+
     def test_update_group_from_grouped_entities(self):
         """Mettre à jour un groupe issu de get_grouped_entities met à jour les entités."""
 


### PR DESCRIPTION
## Summary
- ensure grouped entity statistics account for the total_occurrences metadata and expanded position lists
- exercise the new behavior with a dedicated unit test covering aggregated occurrences

## Testing
- pytest tests/test_entity_manager.py::TestGroupManagement::test_grouped_entities_use_total_occurrences_metadata

------
https://chatgpt.com/codex/tasks/task_e_68e6213f5e10832d9ca13e120dae4afb