### PR TITLE
Ensure edited groups refresh after save

### DIFF
--- a/src/streamlit_legal_ui.py
+++ b/src/streamlit_legal_ui.py
@@ -260,7 +260,13 @@ def display_legal_entity_manager(
                         )
                         for v in group["variants"].keys():
                             entity_manager.update_token_variants(new_token, v)
+                        updated_groups = [
+                            {"id": gid, **data}
+                            for gid, data in entity_manager.get_grouped_entities().items()
+                        ]
+                        groups[:] = updated_groups
                     st.session_state["editing_group"] = None
+                    st.rerun()
                 if st.button(texts["delete_cancel"], key="cancel_edit"):
                     st.session_state["editing_group"] = None
 


### PR DESCRIPTION
## Summary
- rerun the Streamlit app after saving edits so the table reflects the updated data
- refresh the local groups list from the entity manager after persisting changes

## Testing
- pytest tests/test_streamlit_group_ui.py

------
https://chatgpt.com/codex/tasks/task_e_68e623a59d24832d8e011a885ab321fb