### PR TITLE
Ensure editing variants replaces previous values

### DIFF
--- a/src/streamlit_legal_ui.py
+++ b/src/streamlit_legal_ui.py
@@ -271,8 +271,10 @@ def display_legal_entity_manager(
                                 "variants": group["variants"],
                             },
                         )
-                        for v in group["variants"].keys():
-                            entity_manager.update_token_variants(new_token, v)
+                        entity_manager.replace_token_variants(
+                            new_token,
+                            group["variants"].keys(),
+                        )
                         updated_groups = [
                             {"id": gid, **data}
                             for gid, data in entity_manager.get_grouped_entities().items()


### PR DESCRIPTION
## Summary
- add an EntityManager helper that overwrites the variants stored on entities for a token
- update the group editing flow to persist manual variants and reuse the helper when saving changes

## Testing
- pytest *(fails: missing `fr_core_news_lg` spaCy model and AI anonymizer expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68e64b5ad5d0832d93a184d249ffde47